### PR TITLE
Support multisite when detecting if WooCommerce is active.

### DIFF
--- a/archive-customiser.php
+++ b/archive-customiser.php
@@ -15,10 +15,14 @@ Domain Path: /languages/
 */
 
 /**
+ * Required for plugin detection
+ **/
+include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+
+/**
  * Check if WooCommerce is active
  **/
-if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) {
-
+if ( is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
 	/**
 	 * Localisation
 	 **/


### PR DESCRIPTION
Hi! Thanks for the plugin! :+1:

We're using it on a multisite installation, and it only detects woocommerce on the main site. This fix that.