### PR TITLE
Hide Elements with CSS as a Fallback

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -35,13 +35,12 @@
   margin-right: 0;
 }
 
-
-.woocommerce.post-type-archive-product .wc_pac_hide_sale_flash .product .onsale,
-.woocommerce.post-type-archive-product .wc_pac_hide_product_count .woocommerce-result-count,
-.woocommerce.post-type-archive-product .wc_pac_hide_product_sorting .woocommerce-ordering,
-.woocommerce.post-type-archive-product .wc_pac_hide_add_to_cart .product .add_to_cart_button,
-.woocommerce.post-type-archive-product .wc_pac_hide_thumbnail .product .wp-post-image,
-.woocommerce.post-type-archive-product .wc_pac_hide_price .product .price,
-.woocommerce.post-type-archive-product .wc_pac_hide_rating .product .star-rating {
+.woocommerce.post-type-archive-product.wc_pac_hide_sale_flash .product .onsale,
+.woocommerce.post-type-archive-product.wc_pac_hide_product_count .woocommerce-result-count,
+.woocommerce.post-type-archive-product.wc_pac_hide_product_sorting .woocommerce-ordering,
+.woocommerce.post-type-archive-product.wc_pac_hide_add_to_cart .product .add_to_cart_button,
+.woocommerce.post-type-archive-product.wc_pac_hide_thumbnail .product .wp-post-image,
+.woocommerce.post-type-archive-product.wc_pac_hide_price .product .price,
+.woocommerce.post-type-archive-product.wc_pac_hide_rating .product .star-rating {
   display: none;
 }

--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -34,3 +34,14 @@
 .woocommerce-page.product-columns-5 ul.products li.product.last {
   margin-right: 0;
 }
+
+
+.woocommerce.post-type-archive-product .wc_pac_hide_sale_flash .product .onsale,
+.woocommerce.post-type-archive-product .wc_pac_hide_product_count .woocommerce-result-count,
+.woocommerce.post-type-archive-product .wc_pac_hide_product_sorting .woocommerce-ordering,
+.woocommerce.post-type-archive-product .wc_pac_hide_add_to_cart .product .add_to_cart_button,
+.woocommerce.post-type-archive-product .wc_pac_hide_thumbnail .product .wp-post-image,
+.woocommerce.post-type-archive-product .wc_pac_hide_price .product .price,
+.woocommerce.post-type-archive-product .wc_pac_hide_rating .product .star-rating {
+  display: none;
+}

--- a/assets/css/layout.less
+++ b/assets/css/layout.less
@@ -50,13 +50,13 @@
 }
 
 .woocommerce.post-type-archive-product {
-	.wc_pac_hide_sale_flash .product .onsale,
-	.wc_pac_hide_product_count .woocommerce-result-count,
-	.wc_pac_hide_product_sorting .woocommerce-ordering,
-	.wc_pac_hide_add_to_cart .product .add_to_cart_button,
-	.wc_pac_hide_thumbnail .product .wp-post-image,
-	.wc_pac_hide_price .product .price,
-	.wc_pac_hide_rating .product .star-rating {
+	&.wc_pac_hide_sale_flash .product .onsale,
+	&.wc_pac_hide_product_count .woocommerce-result-count,
+	&.wc_pac_hide_product_sorting .woocommerce-ordering,
+	&.wc_pac_hide_add_to_cart .product .add_to_cart_button,
+	&.wc_pac_hide_thumbnail .product .wp-post-image,
+	&.wc_pac_hide_price .product .price,
+	&.wc_pac_hide_rating .product .star-rating {
 		display: none;
 	}
 }

--- a/assets/css/layout.less
+++ b/assets/css/layout.less
@@ -48,3 +48,15 @@
 		}
 	}
 }
+
+.woocommerce.post-type-archive-product {
+	.wc_pac_hide_sale_flash .product .onsale,
+	.wc_pac_hide_product_count .woocommerce-result-count,
+	.wc_pac_hide_product_sorting .woocommerce-ordering,
+	.wc_pac_hide_add_to_cart .product .add_to_cart_button,
+	.wc_pac_hide_thumbnail .product .wp-post-image,
+	.wc_pac_hide_price .product .price,
+	.wc_pac_hide_rating .product .star-rating {
+		display: none;
+	}
+}

--- a/woocommerce-product-archive-customiser.php
+++ b/woocommerce-product-archive-customiser.php
@@ -53,6 +53,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 				add_action( 'wp_enqueue_scripts', array( $this, 'wc_pac_styles' ) );
 				add_action( 'init', array( $this, 'wc_pac_setup' ) );
 				add_action( 'wp', array( $this, 'wc_pac_fire_customisations' ) );
+				add_filter( 'body_class', array( $this, 'wc_pac_fire_customisation_styles' ) );
 				add_action( 'wp', array( $this, 'wc_pac_columns' ) );
 				add_filter( 'loop_shop_per_page', array( $this, 'woocommerce_pac_products_per_page' ), 20 );
 
@@ -517,6 +518,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 			 * @return void
 			 */
 			function wc_pac_fire_customisations() {
+
 				// Sale flash.
 				if ( get_theme_mod( 'wc_pac_sale_flash', false ) === false ) {
 					remove_action( 'woocommerce_before_shop_loop_item_title', 'woocommerce_show_product_loop_sale_flash', 10 );
@@ -566,6 +568,58 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 				if ( get_theme_mod( 'wc_pac_categories', false ) === true ) {
 					add_action( 'woocommerce_after_shop_loop_item', array( $this, 'woocommerce_pac_show_product_categories' ), 30 );
 				}
+
+			}
+
+			/**
+			 * Some plugins or themes may have already customized the hooks
+			 * We'll add body classes to the page and hide elements with CSS as a fall back
+			 *
+			 * @return $body_classes
+			 * @since 1.0.4
+			 * @see https://github.com/jameskoster/woocommerce-product-archive-customiser/issues/22
+			 */
+			function wc_pac_fire_customisation_styles( $body_classes ) {
+
+				$wc_pac_body_classes = array();
+
+				// Sale flash.
+				if ( get_theme_mod( 'wc_pac_sale_flash', false ) === false ) {
+					$wc_pac_body_classes[] = 'wc_pac_hide_sale_flash';
+				}
+
+				// Result Count.
+				if ( get_theme_mod( 'wc_pac_product_count', true ) === false ) {
+					$wc_pac_body_classes[] = 'wc_pac_hide_product_count';
+				}
+
+				// Product Ordering.
+				if ( get_theme_mod( 'wc_pac_product_sorting', true ) === false ) {
+					$wc_pac_body_classes[] = 'wc_pac_hide_product_sorting';
+				}
+
+				// Add to cart button.
+				if ( get_theme_mod( 'wc_pac_add_to_cart', true ) === false ) {
+					$wc_pac_body_classes[] = 'wc_pac_hide_add_to_cart';
+				}
+
+				// Thumbnail.
+				if ( get_theme_mod( 'wc_pac_thumbnail', true ) === false ) {
+					$wc_pac_body_classes[] = 'wc_pac_hide_thumbnail';
+				}
+
+				// Price.
+				if ( get_theme_mod( 'wc_pac_price', true ) === false ) {
+					$wc_pac_body_classes[] = 'wc_pac_hide_price';
+				}
+
+				// Rating.
+				if ( get_theme_mod( 'wc_pac_rating', true ) === false ) {
+					$wc_pac_body_classes[] = 'wc_pac_hide_rating';
+				}
+
+				// Add the body classes to the body
+				return array_merge( $body_classes, $wc_pac_body_classes );
 			}
 
 			/**


### PR DESCRIPTION
Hiding elements with CSS as a fall back for when other themes/plugins change hook priorities.

Fixes #22 